### PR TITLE
[upgrade] Support latest Meteor API (v2.3.2)

### DIFF
--- a/package.js
+++ b/package.js
@@ -7,7 +7,7 @@ Package.describe({
 })
 
 Package.onUse((api) => {
-  api.versionsFrom('METEOR@1.8.1')
+  api.versionsFrom(['METEOR@1.8.1', 'METEOR@2.3.2'])
   api.use('modules')
   api.use('promise')
   api.use('ecmascript')


### PR DESCRIPTION
A major version hike in `accounts-base` was previously preventing Meteor projects that use `epfl:accounts-tequila` from doing `meteor update`.

Tested: all three points of adherence with the `Accounts` API i.e.
- deliberately failing a Tequila redirect (by appending a bogus `?key=`) still triggers the `defaultLoginFailureHandler` (covers the call to `Accounts.onLoginFailure` in accounts-tequila-client.js);
- the module still works in the happy-path (covers the other two calls)